### PR TITLE
fix(deploy): poll workflow list page for DEPLOY PENDING

### DIFF
--- a/tests/test_deploy/test_deploy_async.py
+++ b/tests/test_deploy/test_deploy_async.py
@@ -283,9 +283,12 @@ class TestDeployWorkflow:
 
         mock_page = AsyncMock()
         mock_page.wait_for_selector = AsyncMock(return_value=mock_button)
+        # Mock evaluate to return False for DEPLOY PENDING check (no pending)
+        mock_page.evaluate = AsyncMock(return_value=False)
+        mock_page.goto = AsyncMock()
         syncer.page = mock_page
 
-        result = await syncer.deploy_workflow()
+        result = await syncer.deploy_workflow("Test Workflow")
 
         assert result is True
         mock_button.click.assert_called_once()


### PR DESCRIPTION
## Summary
- Added `_wait_for_deploy_completion()` method that polls the workflow list page after clicking Deploy
- Checks for "DEPLOY PENDING" text to disappear before reporting success
- Timeout of 30 seconds with 2-second polling interval
- Modified `deploy_workflow()` to accept workflow name and call completion check

## Problem
After clicking Deploy, the script only waited 2 seconds before moving on. For workflows with more code (like gmail_to_notion with 3 steps), deployment can take longer, leaving the workflow in "DEPLOY PENDING" state.

## Solution
Instead of just waiting 2 seconds, the script now:
1. Navigates to the workflow list page
2. Polls for "DEPLOY PENDING" text to disappear
3. Times out after 30 seconds if still pending
4. Reports warning if deployment doesn't complete in time

## Test plan
- [x] All 289 tests pass
- [ ] Deploy multi-step workflow and verify no DEPLOY PENDING

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment process now properly waits for completion instead of immediately assuming success, improving reliability.
  * Enhanced per-workflow deployment tracking and status verification with timeout protection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->