### PR TITLE
fix(deploy): add wait after Deploy click to prevent race condition

### DIFF
--- a/config/pipedream-mapping.yaml
+++ b/config/pipedream-mapping.yaml
@@ -78,7 +78,7 @@ settings:
   autosave_wait: 3
 
   # Run in headless mode (true for CI, false for debugging)
-  headless: true
+  headless: false
 
   # Screenshot configuration
   screenshot_on_failure: true


### PR DESCRIPTION
## Summary

- Fixed race condition where navigating away immediately after clicking Deploy aborted the deploy API request, leaving workflows stuck in "DEPLOY PENDING" status
- Added 3-second wait after Deploy click to allow API request to complete
- Added debug screenshots at critical points for troubleshooting
- Added verbose logging of visible workflows on list page

## Problem

Workflows were randomly staying in "DEPLOY PENDING" status after running `/deploy_to_pd`. The root cause was a race condition: the script navigated to the workflow list page immediately after clicking Deploy, which caused the browser to abort the in-flight deploy API request.

## Solution

Added a 3-second wait after clicking the Deploy button before navigating away. This gives Pipedream's backend time to receive and process the deploy request.

## Changes

- `src/deploy/deploy_to_pipedream.py`: Added wait, screenshots, and logging
- `config/pipedream-mapping.yaml`: Set `headless: false` for debugging
- `docs/DEPLOY_IMPLEMENTATION.md`: Added documentation for the race condition fix

## Test Plan

- [x] All 289 tests pass
- [x] Deployed all 4 workflows successfully twice with no DEPLOY PENDING issues
- [x] Verified each workflow's steps after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Switched default run mode from headless to interactive for improved debugging capability.

* **Documentation**
  * Expanded deployment guides with race condition mitigation strategies and verification procedures.
  * Added troubleshooting section for deployment status issues.

* **Improvements**
  * Enhanced deployment process with improved logging and visual confirmation checks for better visibility during operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->