### PR TITLE
fix: remove Processed by Dara dependency + fix horizon score task IDs

### DIFF
--- a/src/steps/google_to_notion.py
+++ b/src/steps/google_to_notion.py
@@ -8,13 +8,8 @@ Page ID for syncing updates back to Notion. Also syncs completion status.
 Usage: Copy-paste into a Pipedream Python step
 """
 import logging
-import os
 import re
-from typing import Optional
-
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 # Configure logging for Pipedream
 logger = logging.getLogger()
@@ -155,62 +150,6 @@ def format_notion_date(due_date):
     return due_date.split('T')[0]
 
 
-def check_processed_by_dara(page_id: str, notion_token: str) -> Optional[bool]:
-    """
-    Check if a Notion page has "Processed by Dara" checkbox set to true.
-
-    Args:
-        page_id: The Notion page ID (32 hex characters).
-        notion_token: The Notion API token.
-
-    Returns:
-        True if the checkbox is checked, False if unchecked,
-        None if verification failed (missing token or API error).
-    """
-    if not notion_token:
-        logger.warning("No Notion token available, cannot check 'Processed by Dara'")
-        return None
-
-    # Format page_id with hyphens for Notion API
-    formatted_id = f"{page_id[:8]}-{page_id[8:12]}-{page_id[12:16]}-{page_id[16:20]}-{page_id[20:]}"
-
-    url = f"https://api.notion.com/v1/pages/{formatted_id}"
-    headers = {
-        "Authorization": f"Bearer {notion_token}",
-        "Notion-Version": "2022-06-28"
-    }
-
-    try:
-        # Use retry with backoff for transient 429/5xx errors
-        session = requests.Session()
-        retries = Retry(
-            total=3,
-            backoff_factor=0.5,
-            status_forcelist=(429, 500, 502, 503, 504),
-            allowed_methods=("GET",),
-        )
-        session.mount("https://", HTTPAdapter(max_retries=retries))
-        response = session.get(url, headers=headers, timeout=10)
-        response.raise_for_status()
-        page_data = response.json()
-
-        # Check for "Processed by Dara" checkbox property
-        processed_prop = safe_get(page_data, ["properties", "Processed by Dara", "checkbox"])
-
-        if processed_prop is True:
-            logger.info("Page %s has 'Processed by Dara' = True", page_id)
-            return True
-
-        return False
-
-    except requests.RequestException as e:
-        logger.warning("Failed to fetch Notion page %s: %s", page_id, e)
-        return None
-    except ValueError as e:
-        logger.warning("Invalid JSON for Notion page %s: %s", page_id, e)
-        return None
-
-
 def handler(pd: "pipedream"):
     """
     Processes Google Tasks triggers, checks if they originated from Notion,
@@ -244,31 +183,7 @@ def handler(pd: "pipedream"):
 
     logger.info(f"Extracted and validated Notion Page ID: {page_id}")
 
-    # --- 3. Check if task was already processed by Dara ---
-    # If "Processed by Dara" checkbox is checked, skip updating List status
-    # to prevent overwriting Dara's status changes
-    notion_token = os.environ.get("NOTION_TOKEN") or os.environ.get("NOTION_API_KEY")
-    processed_by_dara = check_processed_by_dara(page_id, notion_token)
-
-    if processed_by_dara is None:
-        exit_message = (
-            f"Unable to verify 'Processed by Dara' status for task '{task_title}'. "
-            "Skipping update to avoid overwriting Dara's changes."
-        )
-        logger.warning(exit_message)
-        pd.flow.exit(exit_message)
-        return
-
-    if processed_by_dara:
-        exit_message = (
-            f"Task '{task_title}' has 'Processed by Dara' checked. "
-            "Skipping List update to preserve Dara's status."
-        )
-        logger.info(exit_message)
-        pd.flow.exit(exit_message)
-        return
-
-    # --- 4. Extract Task Status (for completion sync) ---
+    # --- 3. Extract Task Status (for completion sync) ---
     task_status = safe_get(task_data, ["status"])  # "completed" or "needsAction"
     logger.info(f"Task status: {task_status}")
 
@@ -280,12 +195,12 @@ def handler(pd: "pipedream"):
 
     logger.info(f"Mapped to Notion List value: {list_value}")
 
-    # --- 5. Extract Due Date ---
+    # --- 4. Extract Due Date ---
     due_date = safe_get(task_data, ["due"])
     notion_due_date = format_notion_date(due_date)
     logger.info(f"Due date: {notion_due_date}")
 
-    # --- 6. Prepare Return Value ---
+    # --- 5. Prepare Return Value ---
     ret_val = {
         "NotionUpdate": {
             "PageId": page_id,
@@ -299,5 +214,5 @@ def handler(pd: "pipedream"):
 
     logger.info(f"Returning: {ret_val}")
 
-    # --- 7. Return data for use in future steps ---
+    # --- 6. Return data for use in future steps ---
     return ret_val

--- a/src/steps/update_horizon_scores.py
+++ b/src/steps/update_horizon_scores.py
@@ -975,7 +975,6 @@ def score_tasks_batch(tasks, rubric, anthropic_key, session=None):
     for i, task in enumerate(tasks, 1):
         tasks_text += f"""
 Task {i}:
-- ID: {task['id']}
 - Title: {task['title']}
 - List: {task['list']}
 - Project: {task['project'] or 'None'}
@@ -1000,9 +999,11 @@ For each task, provide a score from 0-100 based on alignment with the Horizons o
 - 30-49: Neutral maintenance task or loosely connected
 - 0-29: Misaligned, distraction, or contrary to stated priorities
 
+Return exactly {len(tasks)} scores, one per task, in the same order as listed above.
+
 Return your response as a JSON array with this exact format:
 [
-  {{"task_id": "xxx", "score": 85, "reasoning": "Brief explanation"}},
+  {{"score": 85, "reasoning": "Brief explanation"}},
   ...
 ]
 
@@ -1022,6 +1023,19 @@ IMPORTANT: Return ONLY the JSON array, no other text."""
             )
         json_str = response_text[start_idx:end_idx]
         scores = json.loads(json_str)
+
+        # Validate score count matches task count
+        if len(scores) != len(tasks):
+            print(
+                f"Warning: Score count mismatch: got {len(scores)} scores "
+                f"for {len(tasks)} tasks. Truncating to min."
+            )
+            scores = scores[:len(tasks)]
+
+        # Inject known-good task IDs by position (never trust Claude with IDs)
+        for i, score_entry in enumerate(scores):
+            score_entry["task_id"] = tasks[i]["id"]
+
         return scores
     except json.JSONDecodeError as e:
         raise HorizonScoringError(

--- a/tests/test_google_to_notion.py
+++ b/tests/test_google_to_notion.py
@@ -4,7 +4,6 @@ Tests for google_to_notion.py Pipedream step.
 import pytest
 import sys
 import os
-from unittest.mock import patch
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -108,8 +107,7 @@ class TestHandler:
 
         assert mock_pd.flow.exit_called is True
 
-    @patch('steps.google_to_notion.check_processed_by_dara', return_value=False)
-    def test_processes_notion_linked_task(self, mock_check, mock_pd, sample_gtask_trigger):
+    def test_processes_notion_linked_task(self, mock_pd, sample_gtask_trigger):
         mock_pd.steps = sample_gtask_trigger
 
         result = handler(mock_pd)
@@ -119,8 +117,7 @@ class TestHandler:
         assert result["NotionUpdate"]["PageId"] is not None
         assert len(result["NotionUpdate"]["PageId"]) == 32
 
-    @patch('steps.google_to_notion.check_processed_by_dara', return_value=False)
-    def test_maps_completed_status(self, mock_check, mock_pd, sample_gtask_trigger_completed):
+    def test_maps_completed_status(self, mock_pd, sample_gtask_trigger_completed):
         mock_pd.steps = sample_gtask_trigger_completed
 
         result = handler(mock_pd)
@@ -128,16 +125,14 @@ class TestHandler:
         assert mock_pd.flow.exit_called is False
         assert result["NotionUpdate"]["ListValue"] == "Completed"
 
-    @patch('steps.google_to_notion.check_processed_by_dara', return_value=False)
-    def test_maps_incomplete_status(self, mock_check, mock_pd, sample_gtask_trigger):
+    def test_maps_incomplete_status(self, mock_pd, sample_gtask_trigger):
         mock_pd.steps = sample_gtask_trigger
 
         result = handler(mock_pd)
 
         assert result["NotionUpdate"]["ListValue"] == "Next Actions"
 
-    @patch('steps.google_to_notion.check_processed_by_dara', return_value=False)
-    def test_extracts_due_date(self, mock_check, mock_pd, sample_gtask_trigger):
+    def test_extracts_due_date(self, mock_pd, sample_gtask_trigger):
         mock_pd.steps = sample_gtask_trigger
 
         result = handler(mock_pd)
@@ -159,22 +154,3 @@ class TestHandler:
         assert mock_pd.flow.exit_called is True
         assert "Could not reliably extract" in mock_pd.flow.exit_message
 
-    @patch('steps.google_to_notion.check_processed_by_dara', return_value=True)
-    def test_exits_when_processed_by_dara(self, mock_check, mock_pd, sample_gtask_trigger):
-        """Handler should exit early if task was already processed by Dara."""
-        mock_pd.steps = sample_gtask_trigger
-
-        handler(mock_pd)
-
-        assert mock_pd.flow.exit_called is True
-        assert "Processed by Dara" in mock_pd.flow.exit_message
-
-    @patch('steps.google_to_notion.check_processed_by_dara', return_value=None)
-    def test_exits_when_dara_check_fails(self, mock_check, mock_pd, sample_gtask_trigger):
-        """Handler should exit early if unable to verify Processed by Dara status."""
-        mock_pd.steps = sample_gtask_trigger
-
-        handler(mock_pd)
-
-        assert mock_pd.flow.exit_called is True
-        assert "Unable to verify" in mock_pd.flow.exit_message

--- a/tests/test_horizon_scores.py
+++ b/tests/test_horizon_scores.py
@@ -285,8 +285,8 @@ class TestScoreTasksBatch:
     @patch('steps.update_horizon_scores.call_claude')
     def test_parses_json_response(self, mock_claude):
         mock_claude.return_value = '''[
-            {"task_id": "task_1", "score": 85, "reasoning": "Good alignment"},
-            {"task_id": "task_2", "score": 45, "reasoning": "Moderate alignment"}
+            {"score": 85, "reasoning": "Good alignment"},
+            {"score": 45, "reasoning": "Moderate alignment"}
         ]'''
 
         tasks = [
@@ -306,7 +306,7 @@ class TestScoreTasksBatch:
     def test_handles_json_with_surrounding_text(self, mock_claude):
         # Claude sometimes adds explanatory text around JSON
         mock_claude.return_value = '''Here are the scores:
-        [{"task_id": "task_1", "score": 75, "reasoning": "Aligned"}]
+        [{"score": 75, "reasoning": "Aligned"}]
         That's the result.'''
 
         tasks = [{"id": "task_1", "title": "Task 1", "list": "Next Actions", "project": "", "area": "", "priority": "", "due_date": "", "notes": ""}]
@@ -314,7 +314,47 @@ class TestScoreTasksBatch:
         result = score_tasks_batch(tasks, "test rubric", "test_key")
 
         assert len(result) == 1
+        assert result[0]["task_id"] == "task_1"
         assert result[0]["score"] == 75
+
+    @patch('steps.update_horizon_scores.call_claude')
+    def test_injects_task_ids_positionally(self, mock_claude):
+        """Task IDs are injected by position, not from Claude's response."""
+        mock_claude.return_value = '''[
+            {"task_id": "wrong_id", "score": 90, "reasoning": "Great"},
+            {"score": 60, "reasoning": "OK"}
+        ]'''
+
+        tasks = [
+            {"id": "real_id_1", "title": "Task 1", "list": "Next Actions", "project": "", "area": "", "priority": "", "due_date": "", "notes": ""},
+            {"id": "real_id_2", "title": "Task 2", "list": "Waiting For", "project": "", "area": "", "priority": "", "due_date": "", "notes": ""}
+        ]
+
+        result = score_tasks_batch(tasks, "test rubric", "test_key")
+
+        # Even if Claude returns a wrong task_id, positional injection overrides it
+        assert result[0]["task_id"] == "real_id_1"
+        assert result[1]["task_id"] == "real_id_2"
+
+    @patch('steps.update_horizon_scores.call_claude')
+    def test_truncates_on_score_count_mismatch(self, mock_claude):
+        """Extra scores from Claude are truncated to match task count."""
+        mock_claude.return_value = '''[
+            {"score": 80, "reasoning": "Good"},
+            {"score": 50, "reasoning": "OK"},
+            {"score": 30, "reasoning": "Extra"}
+        ]'''
+
+        tasks = [
+            {"id": "task_1", "title": "Task 1", "list": "Next Actions", "project": "", "area": "", "priority": "", "due_date": "", "notes": ""},
+            {"id": "task_2", "title": "Task 2", "list": "Waiting For", "project": "", "area": "", "priority": "", "due_date": "", "notes": ""}
+        ]
+
+        result = score_tasks_batch(tasks, "test rubric", "test_key")
+
+        assert len(result) == 2
+        assert result[0]["task_id"] == "task_1"
+        assert result[1]["task_id"] == "task_2"
 
     @patch('steps.update_horizon_scores.call_claude')
     def test_raises_on_invalid_json(self, mock_claude):


### PR DESCRIPTION
## Summary

- **Remove "Processed by Dara" check from Google→Notion sync** — The checkbox field was removed from Notion, causing the API to return `None` and hard-block ALL task updates. Deletes `check_processed_by_dara()` and its guard block so syncing resumes immediately.
- **Fix hallucination-prone task IDs in horizon scoring** — Previously sent Notion page IDs to Claude in the prompt and trusted Claude to echo them back. Claude could hallucinate/alter IDs, causing 404 errors on Notion updates. Now injects known-good IDs positionally after scoring.

## Test plan

- [x] All 403 tests pass (`pytest tests/ -v`)
- [x] Removed 2 Dara-specific tests, removed `@patch` decorators from 4 tests
- [x] Added `test_injects_task_ids_positionally` — verifies Claude's hallucinated IDs are overwritten
- [x] Added `test_truncates_on_score_count_mismatch` — verifies extra scores are truncated
- [x] Code review passed (no remaining references to Dara, no unused imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)